### PR TITLE
guide/vuex-store プラグインのコードサンプルを修正

### DIFF
--- a/ja/guide/vuex-store.md
+++ b/ja/guide/vuex-store.md
@@ -172,11 +172,17 @@ export default {
 プラグインを `store/index.js` ファイルに置くことで、ストア（モジュールモード）に追加できます:
 
 ```js
-actions: {
-  nuxtServerInit ({ commit }, { req }) {
-    if (req.session.user) {
-      commit('user', req.session.user)
-    }
+import myPlugin from 'myPlugin'
+
+export const plugins = [ myPlugin ]
+
+export const state = () => ({
+  counter: 0
+})
+
+export const mutations = {
+  increment (state) {
+    state.counter++
   }
 }
 ```


### PR DESCRIPTION
https://ja.nuxtjs.org/guide/vuex-store の「プラグイン」のコードサンプルが「nuxtServerInit アクション」のコードサンプルと同一のものになっていましたので、ENのコードサンプルと同一になるように修正しました。

※ どこに修正のPRを送ればよいかわからなかったので、もしここでないならrejectしてください